### PR TITLE
Most of these hoon-school links have moved

### DIFF
--- a/lessons/lesson01-dojo.md
+++ b/lessons/lesson01-dojo.md
@@ -66,7 +66,7 @@ You've seen `|mount` and `|commit` already, which coordinate the "external" file
 
 As mentioned, Hoon:Urbit::C:Unix.  Similar to how C compiles to assembler for execution, Hoon is a macro language on top of a simple Turing-complete language called Nock.
 
-Urbit is a "subject-oriented" system.  Right now, what that means to you is that rather than an environment stack, Urbit has a nested tree of values:  _everything_ in Urbit is a binary tree.  The [docs](https://urbit.org/docs/tutorials/hoon/the-subject-and-its-legs/) explain this thus:  "every Hoon expression is evaluated relative to some subject, [and] roughly, the subject defines the environment in which a Hoon expression is evaluated."
+Urbit is a "subject-oriented" system.  Right now, what that means to you is that rather than an environment stack, Urbit has a nested tree of values:  _everything_ in Urbit is a binary tree.  The [docs](https://urbit.org/docs/hoon/hoon-school/the-subject-and-its-legs/) explain this thus:  "every Hoon expression is evaluated relative to some subject, [and] roughly, the subject defines the environment in which a Hoon expression is evaluated."
 
 For a userspace program, the subject is Zuse, the standard library (which wraps around Arvo and Hoon).  Dojo provides a slightly broader subject with some convenience features built in to ease programming.  Any Hoon expression (or hoon) evaluates to a tree, wherein each operation is a macro reducing ultimately to Nock.  Hoon is written using "runes," a lapidary composition technique which emphasizes program structure.
 

--- a/lessons/lesson03-generators.md
+++ b/lessons/lesson03-generators.md
@@ -137,8 +137,8 @@ Since there are no formal side effects in purely functional Hoon, there is a hin
 ~&  (add 1 1.000)
 ```
 
-- Reading: [Tlon Corporation, "Walkthrough:  List of Numbers"](https://urbit.org/docs/tutorials/hoon/list-of-numbers/)
-- Reading: [Tlon Corporation, "Gates"](https://urbit.org/docs/tutorials/hoon/gates/) (you should complete the exercises there as well)
+- Reading: [Tlon Corporation, "Walkthrough:  List of Numbers"](https://urbit.org/docs/hoon/hoon-school/list-of-numbers)
+- Reading: [Tlon Corporation, "Gates"](https://urbit.org/docs/hoon/hoon-school/gates) (you should complete the exercises there as well)
 
 
 ##  Generators
@@ -264,8 +264,8 @@ it can be imported for use in another generator `home/gen/abs.hoon` as
 
 and used in Dojo as `+abs .-5`
 
-- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/tutorials/hoon/generators/), section "Naked Generators"
-- Reading: [Tlon Corporation, "Walkthrough:  Recursion"](https://urbit.org/docs/tutorials/hoon/recursion/) (note in particular the better way to carry out recursion)
+- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/hoon/hoon-school/generators#naked-generators), section "Naked Generators"
+- Reading: [Tlon Corporation, "Walkthrough:  Recursion"](https://urbit.org/docs/hoon/hoon-school/recursion/) (note in particular the better way to carry out recursion)
 
 ##  Pronouncing Hoon
 

--- a/lessons/lesson04-aura.md
+++ b/lessons/lesson04-aura.md
@@ -114,7 +114,7 @@ A user can designate any custom aura, but the pretty-printer only knows about th
 `@z`(add 1 a)
 ```
 
-- Reading: [Tlon Corporation, "1.2 Nouns", sections "Atoms" through "Casting to Other Auras"](https://urbit.org/docs/tutorials/hoon/nouns/)
+- Reading: [Tlon Corporation, "1.2 Nouns", sections "Atoms" through "Casting to Other Auras"](https://urbit.org/docs/hoon/hoon-school/nouns/)
 
 ##  Aura-Related Errors
 

--- a/lessons/lesson05-syntax.md
+++ b/lessons/lesson05-syntax.md
@@ -125,9 +125,9 @@ Let's reconsider the binary tree from before:
 
 Every structure being a binary tree, certain common structures arise which contain data at particular addresses.  Most generally, all structures in Hoon are _cores_, which are cells containing a _battery_ and a _payload_, `[battery payload]`.  The battery generally describes "what to do", like methods in an object, while the payload describes "what it is", the actual data.  In common structures, sometimes these take specific names other than battery and payload, but learn to always see these parts in any new structure you encounter in the kernel.
 
-- Reading: [Tlon Corporation, "Nouns"](https://urbit.org/docs/tutorials/hoon/nouns/) (search for "tree" and read those sections)
+- Reading: [Tlon Corporation, "Nouns"](https://urbit.org/docs/hoon/hoon-school/nouns/) (search for "tree" and read those sections)
 - Optional Reading: [Tlon Corporation, "Tree Addressing"](https://urbit.org/docs/reference/library/1b/) (to get the flavor of accessing and manipulating trees)
-- Optional Reading: [Tlon Corporation, "The Subject and Its Legs"](https://urbit.org/docs/tutorials/hoon/the-subject-and-its-legs/), section "Lark Expressions"
+- Optional Reading: [Tlon Corporation, "The Subject and Its Legs"](https://urbit.org/docs/hoon/hoon-school/the-subject-and-its-legs/), section "Lark Expressions"
 
 ![Robert McCall, Rendition of Apollo–Soyuz Encounter](../img/05-header-mccall-2.png)
 
@@ -169,7 +169,7 @@ When you are looking up a rune in the docs, you should search "kethep" instead o
 
 ![](../img/05-hoon-pronunciation.png)
 
-(There is [a chart in the docs](https://urbit.org/docs/tutorials/hoon/hoon-syntax/) which has an alphabetically-ordered equivalent if you prefer.)
+(There is [a chart in the docs](https://urbit.org/docs/hoon/hoon-school/hoon-syntax/) which has an alphabetically-ordered equivalent if you prefer.)
 
 ![Robert McCall, Rendition of Apollo–Soyuz Encounter](../img/05-header-mccall-4.png)
 
@@ -211,7 +211,7 @@ Good Hoon style also mandates backstep indentation, which counters the tendency 
 (ceil a)
 ```
 
-- Optional Reading: [Tlon Corporation, "Hoon Style Guide"](https://urbit.org/docs/tutorials/hoon/style/)
+- Optional Reading: [Tlon Corporation, "Hoon Style Guide"](https://urbit.org/docs/hoon/reference/style)
 
 
 ##  Efficiency

--- a/lessons/lesson06-cores.md
+++ b/lessons/lesson06-cores.md
@@ -104,8 +104,8 @@ For instance, for a gate, the parent core is the subject.  That is, with `[$ [sa
 
 See the Subject-Oriented Language lesson for a deeper dive.
 
--   Reading: [Tlon Corporation, "The Subject and Its Legs", section "A Start"](https://urbit.org/docs/tutorials/hoon/hoon-school/the-subject-and-its-legs/), section "A Start"
--   Reading: [Tlon Corporation, "Gates"](https://urbit.org/docs/tutorials/hoon/hoon-school/gates/), section "What is a Gate?"
+-   Reading: [Tlon Corporation, "The Subject and Its Legs", section "A Start"](https://urbit.org/docs/hoon/hoon-school/the-subject-and-its-legs/), section "A Start"
+-   Reading: [Tlon Corporation, "Gates"](https://urbit.org/docs/hoon/hoon-school/gates/), section "What is a Gate?"
 
 ### Faces
 
@@ -164,7 +164,7 @@ i=~.hello
 ~.hello
 ```
 
-- Reading: [Tlon Corporation, "The Subject and Its Legs"](https://urbit.org/docs/tutorials/hoon/hoon-school/the-subject-and-its-legs/), sections "Faces" and "Duplicate Faces"
+- Reading: [Tlon Corporation, "The Subject and Its Legs"](https://urbit.org/docs/hoon/hoon-school/the-subject-and-its-legs/), sections "Faces" and "Duplicate Faces"
 
 ### Vases
 

--- a/lessons/lesson07-say-generators.md
+++ b/lessons/lesson07-say-generators.md
@@ -121,7 +121,7 @@ Since the default value is `~`, if you are testing for the presence of named arg
 
 Note that, in all of these cases, you are writing a gate `|=` bartis which accepts `[* * ~]` or the like as sample.  Dojo (and Arvo generally) recognizes that `%say` generators have a special format and parse the command-line form into appropriate form for the gate itself.
 
-- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/tutorials/hoon/generators/), sections "%say Generators", "%say generators with arguments", "Arguments without a cell"
+- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/hoon/hoon-school/generators/), sections "%say Generators", "%say generators with arguments", "Arguments without a cell"
 
 ##  Worked Examples
 
@@ -262,8 +262,8 @@ The following Hoon Workbook examples walk you line-by-line through several `%say
 
 The traffic light example is furthermore an excellent prelude to our entrée to Gall.
 
-- Reading: [Tlon Corporation, "Hoon Workbook:  Digits"](https://urbit.org/docs/tutorials/hoon/workbook/digits/)
-- Reading: [Tlon Corporation, "Hoon Workbook:  Magic 8-Ball"](https://urbit.org/docs/tutorials/hoon/workbook/eightball/)
-- Reading: [Tlon Corporation, "Hoon Workbook:  Traffic Light"](https://urbit.org/docs/tutorials/hoon/workbook/traffic-light/)
+- Reading: [Tlon Corporation, "Hoon Workbook:  Digits"](https://web.archive.org/web/20210315002509/https://urbit.org/docs/tutorials/hoon/workbook/digits/)
+- Reading: [Tlon Corporation, "Hoon Workbook:  Magic 8-Ball"](https://web.archive.org/web/20210315002732/https://urbit.org/docs/tutorials/hoon/workbook/eightball/)
+- Reading: [Tlon Corporation, "Hoon Workbook:  Traffic Light"](https://web.archive.org/web/20210315032448/https://urbit.org/docs/tutorials/hoon/workbook/traffic-light/)
 
 ![](../img/07-header-apollo-3.png)

--- a/lessons/lesson08-subject-oriented-programming.md
+++ b/lessons/lesson08-subject-oriented-programming.md
@@ -88,7 +88,7 @@ The current subject (Arvo) is `.`.  (Most of these values are actually hashes st
 ]
 ```
 
-- Reading: [Tlon Corporation, "The Subject and Its Legs", section "A Start"](https://urbit.org/docs/tutorials/hoon/the-subject-and-its-legs/)
+- Reading: [Tlon Corporation, "The Subject and Its Legs", section "A Start"](https://urbit.org/docs/hoon/hoon-school/the-subject-and-its-legs/)
 - Reading: [Tlon Corporation, "Limbs"](https://urbit.org/docs/reference/hoon-expressions/limb/limb/)
 - Reading: [Tlon Corporation, "Wings"](https://urbit.org/docs/reference/hoon-expressions/limb/wing/)
 - Reading: [Ted Blackman `~rovnys-ricfer`, "Why Hoon?"](https://urbit.org/blog/why-hoon/)
@@ -135,7 +135,7 @@ This transparent introspection is extremely powerful, and you'll often see it em
 
 (Gates, therefore, are special cases of doors.  See [`%~` censig](https://urbit.org/docs/reference/hoon-expressions/rune/cen/#censig) for more information.)
 
-- Reading: [Tlon Corporation, "Doors"](https://urbit.org/docs/tutorials/hoon/hoon-school/doors/)
+- Reading: [Tlon Corporation, "Doors"](https://urbit.org/docs/hoon/hoon-school/doors/)
 
 ### Custom Samples
 

--- a/lessons/lesson10-libraries.md
+++ b/lessons/lesson10-libraries.md
@@ -218,7 +218,7 @@ Most of the time, `++expect-eq` is the only arm used.  `++expect-fail` works a b
 
 ##  Hoon Style
 
-It's time for you to read and absorb the [authoritative Hoon style guide](https://urbit.org/docs/tutorials/hoon/style/).  All code you produce subsequently should hew to it, particularly the informal comments.  (It will take us a while yet in this course to get to the point where formal comments are worth the trouble.)
+It's time for you to read and absorb the [authoritative Hoon style guide](https://urbit.org/docs/hoon/reference/style).  All code you produce subsequently should hew to it, particularly the informal comments.  (It will take us a while yet in this course to get to the point where formal comments are worth the trouble.)
 
 It's worth noting that I have a few minor quibbles on style:
 
@@ -251,7 +251,7 @@ For instance, here are samples from some library code I have written, which adhe
 
 How would you rewrite these code snippets in fully-compliant style?
 
-- Reading: [Tlon Corporation, "Hoon Style Guide"](https://urbit.org/docs/tutorials/hoon/style/)
+- Reading: [Tlon Corporation, "Hoon Style Guide"](https://urbit.org/docs/hoon/reference/style)
 
 
 ##  A Word of Encouragement

--- a/lessons/lesson11-ford-1.md
+++ b/lessons/lesson11-ford-1.md
@@ -91,7 +91,7 @@ We can classify a testing regimen into various layers:
 
 3.  Integration tests check on how well your new or updated code integrates with the broader system.  These can be included in continuous integration (CI) frameworks like Circle or Travis-CI.  The Arvo ecosystem isn't large enough for developers outside the kernel itself to worry about this yet.
 
-- Reading: [Tlon Corporation, "Unit Testing with Ford"](https://web.archive.org/web/20200614210451/https://urbit.org/docs/tutorials/hoon/test-sets/)
+- Reading: [Tlon Corporation, "Unit Testing with Ford"](https://web.archive.org/web/20200614210451/https://urbit.org/docs/hoon/hoon-school/test-sets/)
 
 
 ##  Ford Runes

--- a/lessons/lesson12-debugging.md
+++ b/lessons/lesson12-debugging.md
@@ -73,7 +73,7 @@ If you really crash things hard—like crash the executable itself—then it's a
 
 Finally, although hinting at darker powers not yet unleashed, you can start a debugging console with `|start %dbug` and access it at your ship's URL followed by `~debug` (e.g., `http://localhost:8080/~debug`).
 
-- Reading: [Tlon Corporation, "Hoon Errors"](https://urbit.org/docs/tutorials/hoon/hoon-errors/)
+- Reading: [Tlon Corporation, "Hoon Errors"](https://urbit.org/docs/hoon/reference/hoon-errors)
 
 
 ##  Debugging Strategies
@@ -111,6 +111,6 @@ Tlon suggests grading code according to certain stylistic and functional criteri
 
 But don't produce A code on the first pass!  Let the code mature for a while at C or B before you refine it into final form.
 
-- Reading: [Tlon Corportion, "Hoon Style Guide"](https://urbit.org/docs/tutorials/hoon/hoon-school/style/), section "Grading"
+- Reading: [Tlon Corportion, "Hoon Style Guide"](https://urbit.org/docs/hoon/reference/style), section "Grading"
 
 ![](../img/12-header-voyager-3.png)

--- a/lessons/lesson13-ask.md
+++ b/lessons/lesson13-ask.md
@@ -69,6 +69,6 @@ The `generators` library lives in `%home/lib/generators/hoon`.  Unsurprisingly, 
 
 You are primarily interested in employing `++print`, `++prompt`, and `++produce`, all of which are reasonably demonstrated in the example code above and in the documentation.  (Also not `++curl`.)
 
-- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/tutorials/hoon/hoon-school/generators/), section "`%ask` Generators"
+- Reading: [Tlon Corporation, "Generators"](https://urbit.org/docs/hoon/hoon-school/generators/), section "`%ask` Generators"
 
 ![](../img/13-header-neptune.png)

--- a/lessons/lesson14-typechecking.md
+++ b/lessons/lesson14-typechecking.md
@@ -51,10 +51,10 @@ ford: %ride failed to compute type:
 <|d e f|>
 ```
 
-- Reading: [Tlon Corporation, "Molds"](https://urbit.org/docs/tutorials/hoon/hoon-school/molds/)
+- Reading: [Tlon Corporation, "Molds"](https://urbit.org/docs/hoon/hoon-school/molds/)
 - Reading: [Tlon Corporation, "1c Molds and Mold Builders"](https://urbit.org/docs/reference/library/1c/)
-- Reading: [Tlon Corporation, "Type Checking and Type Inference"](https://urbit.org/docs/tutorials/hoon/hoon-school/type-checking-and-type-inference/)
-- Reading: [Tlon Corporation, "Structures and Complex Types"](https://urbit.org/docs/tutorials/hoon/hoon-school/structures-and-complex-types/)
+- Reading: [Tlon Corporation, "Type Checking and Type Inference"](https://urbit.org/docs/hoon/hoon-school/type-checking-and-type-inference/)
+- Reading: [Tlon Corporation, "Structures and Complex Types"](https://urbit.org/docs/hoon/hoon-school/structures-and-complex-types/)
 
 I recommend that you review section Vases in Cores as well.
 
@@ -101,7 +101,7 @@ HOWEVER, dry cores can differ in their variance models.
 
 In practice, gold and iron cores are commonly seen; I've observed far fewer zinc and lead gates in the wild.  Gates constructed with `|` bar runes can be converted using some of the `&` pam runes.
 
-- Reading: [Tlon Corporation, "Type Polymorphism"](https://urbit.org/docs/tutorials/hoon/hoon-school/type-polymorphism/), sections "Dry Cores" and "The Four Kinds of Cores"
+- Reading: [Tlon Corporation, "Type Polymorphism"](https://urbit.org/docs/hoon/hoon-school/type-polymorphism/), sections "Dry Cores" and "The Four Kinds of Cores"
 - Reading: [Tlon Corporation, "Advanced Types"](https://urbit.org/docs/reference/hoon-expressions/advanced/), sections on dry gates in "`%core` Advanced Polymorphism"
 
 We will discuss wet gates in Polymorphism.

--- a/lessons/lesson16-containers.md
+++ b/lessons/lesson16-containers.md
@@ -88,7 +88,7 @@ To change or insert an entry, use the `++put` arm:
 
 (This _returns_ a changed copy; it doesn't alter the original dictionary.)
 
-- Reading: [Tlon Corporation, "Trees, Sets, and Maps"](https://urbit.org/docs/tutorials/hoon/hoon-school/trees-sets-and-maps/)
+- Reading: [Tlon Corporation, "Trees, Sets, and Maps"](https://urbit.org/docs/hoon/hoon-school/trees-sets-and-maps/)
 - Reading: [Tlon Corporation, "Map Logic"](https://urbit.org/docs/reference/library/2i/)
 
 ### Sets
@@ -170,7 +170,7 @@ That produces a list.  If you want to preserve having a map, use `++urn`:
 
 The bomb defusing exercise is a great refresher before we start on Gall next time.  It also uses some of the container logic we developed above.
 
-- Reading: [Tlon Corporation, "Hoon Workbook:  Bomb Defusing"](https://urbit.org/docs/tutorials/hoon/workbook/bomb/)
+- Reading: [Tlon Corporation, "Hoon Workbook:  Bomb Defusing"](https://web.archive.org/web/20210315072208/https://urbit.org/docs/tutorials/hoon/workbook/bomb/)
 
 Dawid Ciezarkiewicz `~napter-matnep` has been working on a Hoon introduction, which may be worth your while to peruse as an alternative explanation of many elementary concepts in Hoon.
 

--- a/lessons/lesson17-gall-1.md
+++ b/lessons/lesson17-gall-1.md
@@ -60,7 +60,7 @@ A minimalist do-nothing default Gall app could look like this:
 ++  on-fail   on-fail:default
 ```
 
-- Reading: [Tlon Corporation, "Gall"](https://urbit.org/docs/tutorials/hoon/hoon-school/gall/)
+- Reading: [Tlon Corporation, "Gall"](https://urbit.org/docs/hoon/hoon-school/gall/)
 - Reading: [Tlon Corporation, "Gall Tutorial"](https://urbit.org/docs/tutorials/arvo/gall/)
 
 
@@ -102,7 +102,7 @@ Report the list of possible move tokens for that Gall app under the `+$command` 
 
 ##  A Minimalist Gall App
 
-Complete the [`egg-timer` app tutorial](https://urbit.org/docs/tutorials/hoon/hoon-school/egg-timer/).
+Complete the [`egg-timer` app tutorial](https://urbit.org/docs/hoon/hoon-school/egg-timer/).
 
 You may start the Gall app using `|start %egg-timer` and poke it using a relative time such as `:egg-timer ~s10`.
 

--- a/lessons/lesson19-text-parsing.md
+++ b/lessons/lesson19-text-parsing.md
@@ -91,7 +91,7 @@ One of the most straightforward tools to use with text is [`++trim`](https://urb
   $(in-words +:values, out-words (weld out-words ~[-:values]))
 ```
 
-- Optional Reading: [Tlon Corporation, "Parsing Hoon"](https://urbit.org/docs/tutorials/hoon/parsing/#parsing-arithmetic-expressions), section "Parsing Arithmetic Expressions"
+- Optional Reading: [Tlon Corporation, "Parsing Hoon"](https://urbit.org/docs/hoon/guides/parsing#parsing-arithmetic-expressions), section "Parsing Arithmetic Expressions"
 
 
 ### Sail & XML Parsing

--- a/lessons/lesson21-behn.md
+++ b/lessons/lesson21-behn.md
@@ -73,7 +73,7 @@ Behn is used commonly in the kernel to maintain the system state, in particular 
 
 > `%eyre` uses `%behn` for timing out sessions, and `%clay` uses `%behn` for keeping track of time-specified file requests.
 
-- Reading: [Tlon Corporation, "Behn Tutorial"](https://urbit.org/docs/tutorials/hoon/hoon-school/behn/)
+- Reading: [Tlon Corporation, "Behn Tutorial"](https://urbit.org/docs/hoon/hoon-school/behn/)
 - Reading: [`behn.hoon`](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/vane/behn.hoon)
 
 ![](../img/21-mccall-1.png)
@@ -85,7 +85,7 @@ _All art by Robert McCall._
 
 ##  A Minimalist Gall App
 
-Return again to the [`egg-timer` app tutorial](https://urbit.org/docs/tutorials/hoon/hoon-school/egg-timer/).
+Return again to the [`egg-timer` app tutorial](https://urbit.org/docs/hoon/hoon-school/egg-timer/).
 
 You may start the Gall app using `|start %egg-timer` and poke it using a relative time such as `:egg-timer ~s10`.
 

--- a/lessons/lesson23-polymorphism.md
+++ b/lessons/lesson23-polymorphism.md
@@ -60,8 +60,8 @@ As a consequence, wet arms and wet cores behave a bit like C++ overloaded operat
 One thing to watch is that `|%` barcen produces dry cores, thus dry arms.  To produce a wet core, you need to use [`|@` barpat](https://urbit.org/docs/reference/hoon-expressions/rune/bar/#barpat) instead.
 
 - Reading: [Tlon Corporation, "Advanced Types"](https://urbit.org/docs/reference/hoon-expressions/advanced/)
-- Reading: [Tlon Corporation, "Iron Polymorphism"](https://urbit.org/docs/tutorials/hoon/hoon-school/iron-polymorphism/)
-- Reading: [Tlon Corporation, "Lead Polymorphism"](https://urbit.org/docs/tutorials/hoon/hoon-school/lead-polymorphism/) <!-- TODO move -->
+- Reading: [Tlon Corporation, "Iron Polymorphism"](https://urbit.org/docs/hoon/hoon-school/iron-polymorphism/)
+- Reading: [Tlon Corporation, "Lead Polymorphism"](https://urbit.org/docs/hoon/hoon-school/lead-polymorphism/) <!-- TODO move -->
 
 
 ##  Type Constructors
@@ -119,8 +119,8 @@ Now we're ready to build a unique Pokémon instance:
 
 [Here is a full implementation of the above as a single generator.](../resources/pokemon.hoon)
 
-- Reading: [Tlon Corporation, "Structures and Complex Types"](https://urbit.org/docs/tutorials/hoon/hoon-school/structures-and-complex-types/)
-- Reading: [Tlon Corporation, "Type Polymorphism"](https://urbit.org/docs/tutorials/hoon/hoon-school/type-polymorphism/)
+- Reading: [Tlon Corporation, "Structures and Complex Types"](https://urbit.org/docs/hoon/hoon-school/structures-and-complex-types/)
+- Reading: [Tlon Corporation, "Type Polymorphism"](https://urbit.org/docs/hoon/hoon-school/type-polymorphism/)
 
 _All art by Robert McCall._
 

--- a/lessons/lesson31-cli.md
+++ b/lessons/lesson31-cli.md
@@ -127,7 +127,7 @@ A simple command parser could look like this:
   (perk %demo %row %table ~)
 ```
 
-`nail`, `++like`, `stag`, and `++perk` are all parsing rule concepts. Parsing rules are complex but can be reviewed in the [text parsing tutorial](https://urbit.org/docs/tutorials/hoon/parsing/).
+`nail`, `++like`, `stag`, and `++perk` are all parsing rule concepts. Parsing rules are complex but can be reviewed in the [text parsing tutorial](https://urbit.org/docs/hoon/guides/parsing).
 
 Once you have a working app, you can use `|link` to connect to it at the console.  Switch to it using `Ctrl`+`X`.  (`|unlink` does the opposite.)
 
@@ -140,7 +140,7 @@ What could you make with a command-line app?  Some ideas:
 
 The sky's the limit!
 
-- Reading: [Tlon Corporation, "CLI apps"](https://urbit.org/docs/tutorials/hoon/cli-tutorial/)
+- Reading: [Tlon Corporation, "CLI apps"](https://urbit.org/docs/hoon/guides/cli-tutorial)
 - Optional Reading: [Tlon Corporation, `lib/shoe.hoon`](https://github.com/urbit/urbit/blob/master/pkg/arvo/lib/shoe.hoon)
 - Optional Reading: [`~hosbud-socbur`, `ed`](https://github.com/crides/ed.hoon)
 

--- a/lessons/lesson33-hoon-1.md
+++ b/lessons/lesson33-hoon-1.md
@@ -111,7 +111,7 @@ Because Hoon rigorously defines all symbols and their interpretations (as does L
 
 The Hoon parser is `++vast`, with the regular form in `++structure:norm:vast` and irregular form in `++scat:vast` and `++scad:vast`.
 
-- Reading:  [Tlon Corporation, "Parsing in Hoon"](https://urbit.org/docs/tutorials/hoon/parsing/)
+- Reading:  [Tlon Corporation, "Parsing in Hoon"](https://urbit.org/docs/hoon/guides/parsing)
 - Reading:  `hoon.hoon`, `++vast` arm
 
 


### PR DESCRIPTION
In some cases like with the workbook links it looks like the pages
no longer exist.